### PR TITLE
[R4R] Oracle logging

### DIFF
--- a/oracle/oracle.js
+++ b/oracle/oracle.js
@@ -1,4 +1,5 @@
 require('dotenv').config()
+require('log-timestamp');
 const kava = require('@kava-labs/javascript-sdk');
 const prices = require(`./prices`).prices
 const utils = require('./utils').utils

--- a/oracle/prices.js
+++ b/oracle/prices.js
@@ -1,3 +1,4 @@
+require('log-timestamp');
 const CoinGecko = require('coingecko-api');
 const coinUtils = require('./utils.js').utils;
 const axios = require('axios')

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-register": "^6.26.0",
     "coingecko-api": "^1.0.10",
     "dotenv": "^8.2.0",
+    "log-timestamp": "^0.3.0",
     "node-cron": "^2.0.3",
     "typescript": "^3.7.5"
   }


### PR DESCRIPTION
Adds a timestamp before PriceOracle's console logs. 

Output:
```
[2020-05-17T19:37:00.256Z] posting price 16.377099999999998658 for bnb:usd
[2020-05-17T19:37:00.291Z] Tx hash: 714341AF0D37BF7B3059E7F3BA5CFE3C71E6989C83DFE9C699A33721548408CD
[2020-05-17T19:38:00.560Z] previous price of 16.377099999999998658 and current price of 16.38250000 for bnb:usd below threshold for posting
[2020-05-17T19:39:00.200Z] previous price of 16.377099999999998658 and current price of 16.40070000 for bnb:usd below threshold for posting
[2020-05-17T19:40:00.225Z] previous price of 16.377099999999998658 and current price of 16.38050000 for bnb:usd below threshold for posting
[2020-05-17T19:41:00.289Z] previous price of 16.377099999999998658 and current price of 16.38260000 for bnb:usd below threshold for posting
```